### PR TITLE
Bugfixes and new features cycle 23/2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,13 +25,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache mamba
-        uses: actions/cache@v3
-        env:
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key: mamba-${{ hashFiles('environment.yml') }}
+      #- name: Cache mamba
+      #  uses: actions/cache@v3
+      #  env:
+      #    CACHE_NUMBER: 0
+      #  with:
+      #    path: ~/conda_pkgs_dir
+      #    key: mamba-${{ hashFiles('environment.yml') }}
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2.2.0
@@ -51,7 +51,7 @@ jobs:
           path: |
             InstrumentFiles
             datafiles
-          key: inst_data_cache
+          key: cached-data-${{ hashFiles('**/cached_git_hashes') }}
 
       - name: Install Mantid
         run: |
@@ -60,16 +60,25 @@ jobs:
       - name: Clone data instrument files
         if: ${{ steps.cache-files.outputs.cache-hit != 'true' }}
         run: |
-          git clone --depth=1 https://github.com/pace-neutrons/InstrumentFiles.git
-          git clone --depth=1 https://github.com/mducle/direct_reduction_test.git
-          mv direct_reduction_test/datafiles ./
+          git clone https://github.com/pace-neutrons/InstrumentFiles.git
+          git clone https://github.com/mducle/direct_reduction_test.git
+          cp -rpa direct_reduction_test/datafiles ./
+
+      - name: Update data instrument files
+        run: |
+          cwd=$(pwd)
+          cd $cwd/InstrumentFiles && git pull && git rev-parse --short HEAD > ../datafiles/cached_git_hashes
+          cd $cwd/direct_reduction_test && git pull && git rev-parse --short HEAD >> cached_git_hashes
+          cd $cwd && rsync -av direct_reduction_test/datafiles/ datafiles/
 
       - name: Run Tests and Coverage
         run: |
-          coverage run -m pytest
+          cd tests
+          coverage run --source=.. run_test.py
 
       - name: Report Coverage
         run: |
+          cd tests
           coverage report
 
       #- name: Setup tmate

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ let_whitevan.py
 let_reduction.py
 mari_whitevan.py
 mari_reduction.py
+mari_reduction_lowE.py
+mari_reduction_existing.py
 maps_whitevan.py
 maps_reduction.py
 merlin_whitevan.py
@@ -16,3 +18,4 @@ MAR*nxs*
 MAP*nxs*
 MER*nxs*
 WV*txt
+InstrumentFiles

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 
 let_whitevan.py
 let_reduction.py
+let_reduction_angle.py
 mari_whitevan.py
 mari_reduction.py
 mari_reduction_lowE.py

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,3 @@ dependencies:
   - ipython
   - mock
   - pip
-  - pytest

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -18,7 +18,7 @@
 from mantid.simpleapi import *
 from mantid.api import AnalysisDataService as ADS
 import numpy as np
-import re, os, h5py
+import os, sys
 import time
 from importlib import reload
 
@@ -69,51 +69,6 @@ def tryload(irun):              # loops till data file appears
         break
 #========================================================
 
-#========================================================
-# Functions to copy instrument info needed by HORACE
-# Resolution convolution if it exists in the raw file
-def get_raw_file_from_ws(ws):
-    for alg in [h for h in ws.getHistory().getAlgorithmHistories() if 'Load' in h.name()]:
-        for prp in [a for a in alg.getProperties() if 'Filename' in a.name()]:
-            if re.search('[0-9]*.nxs', prp.value()) is not None:
-                return prp.value()
-    raise RuntimeError('Could not find raw NeXus file in workspace history')
-
-def copy_inst_info(outfile, in_ws):
-    try:
-        raw_file_name = get_raw_file_from_ws(mtd[in_ws])
-    except RuntimeError:
-        return
-    print(raw_file_name)
-    if not os.path.exists(outfile):
-        outfile = os.path.join(mantid.simpleapi.config['defaultsave.directory'], os.path.basename(outfile))
-    print(outfile)
-    with h5py.File(raw_file_name, 'r') as raw:
-        with h5py.File(outfile, 'r+') as spe:
-            exclude = ['dae', 'detector_1', 'name']
-            to_copy = [k for k in raw['/raw_data_1/instrument'] if not any([x in k for x in exclude])]
-            print(spe.keys())
-            spe_root = list(spe.keys())[0]
-            en0 = spe[f'{spe_root}/instrument/fermi/energy'][()]
-            if 'fermi' in to_copy:
-                del spe[f'{spe_root}/instrument/fermi']
-            for grp in to_copy:
-                print(grp)
-                src = raw[f'/raw_data_1/instrument/{grp}']
-                h5py.Group.copy(src, src, spe[f'{spe_root}/instrument/'])
-            if 'fermi' in to_copy:
-                spe[f'{spe_root}/instrument/fermi/energy'][()] = en0
-            detroot = f'{spe_root}/instrument/detector_elements_1'
-            spe.create_group(detroot)
-            for df0, df1 in zip(['SPEC', 'UDET', 'DELT', 'LEN2', 'CODE', 'TTHE', 'UT01'], \
-                ['spectrum_number', 'detector_number', 'delt', 'distance', 'detector_code', 'polar_angle', 'azimuthal_angle']):
-                src = raw[f'/raw_data_1/isis_vms_compat/{df0}']
-                h5py.Group.copy(src, src, spe[detroot], df1)
-            for nn in range(raw['/raw_data_1/isis_vms_compat/NUSE'][0]):
-                src = raw[f'/raw_data_1/isis_vms_compat/UT{nn+1:02d}']
-                h5py.Group.copy(src, src, spe[detroot], f'user_table{nn+1:02d}')
-#========================================================
-
 # ==============================setup directroties================================
 config['default.instrument'] = inst
 if save_dir is not None:
@@ -143,10 +98,19 @@ else:
 
 cycle_shortform = cycle[2:] if cycle.startswith('20') else cycle
 datadir = f'/archive/NDX{inst}/Instrument/data/cycle_{cycle_shortform}/'
-mapdir  = f'/usr/local/mprogs/InstrumentFiles/{inst.swapcase()}/'
+instfiles  = '/usr/local/mprogs/InstrumentFiles/'
+mapdir  = f'{instfiles}/{inst.swapcase()}/'
 config.appendDataSearchDir(mapdir)
 config.appendDataSearchDir(datadir)
 ws_list = ADS.getObjectNames()
+
+# Try to load subsidiary utilities
+sys.path.append(instfiles)
+try:
+    from reduction_utils import *
+    utils_loaded = True
+except ImportError:
+    utils_loaded = False
 
 print(f'\n======= {inst} data reduction =======')
 print(f'Working directory... {ConfigService.Instance().getString("defaultsave.directory")}\n')
@@ -325,9 +289,10 @@ for irun in sample:
         print(f'{inst}: Writing {ofile}{saveformat}')
         if saveformat.lower() == '.nxspe':
             SaveNXSPE('ws_out', ofile+saveformat, Efixed=Ei, KiOverKfScaling=True)
+            if utils_loaded:
+                copy_inst_info(ofile+saveformat, 'ws_out')   # Copies instrument info for Horace
         elif saveformat.lower() == '.nxs':
             SaveNexus('ws_out', ofile+saveformat)
-            copy_inst_info(ofile+saveformat, 'ws_out')
         if QENS:
             print('... outputting QENS "_red" format')
             theta = np.array([theta_range[0], theta_range[1]])*np.pi/180.

--- a/reduction_files/DG_whitevan.py
+++ b/reduction_files/DG_whitevan.py
@@ -23,7 +23,6 @@ t = time.time()         #start the clock
 whitevan       = 78715                  # white vanadium run
 whitevan_bg    = None                   # background for the white vanadium
 whitevan_trans = 1                      # transmission factor
-mask_file      = 'MASK_FILE_XML'        # hardmask file (str or None)
 #========================================================
 
 #==================Local Contact Inputs==================
@@ -32,7 +31,6 @@ cycle = 'CYCLE_ID'                      # cycle
 wv_lrange = [1,5]                       # wavelength integration limits for output of vanadium integrals
 wv_detrange = [30000,60000]             # spectrum index range for average intensity calculation
 idebug = False                          # keep itermediate workspaces for debugging
-mask_dir = None                         # folder for mask file (str or None)
 save_dir = f'/instrument/{inst}/RBNumber/USER_RB_FOLDER' # Set to None to avoid resetting
 #========================================================
 
@@ -72,11 +70,6 @@ print('... Calculating white vanadium integrals')
 print(f'... Summing between {wv_lrange[0]:.1f} < \u03BB < {wv_lrange[1]:.1f} \u212B')
 WV_normalised_integrals = ConvertUnits(wv_corrected, 'Wavelength')
 WV_normalised_integrals = Rebin(WV_normalised_integrals, f'{wv_lrange[0]},100,{wv_lrange[1]}', PreserveEvents=False)
-if mask_file is not None:
-    if mask_dir is not None:
-        config.appendDataSearchDir(mask_dir)
-    LoadMask(inst, mask_file, OutputWorkspace=mask_file)
-    MaskDetectors(WV_normalised_integrals, MaskedWorkspace=mask_file)
 wv_normt = Transpose(WV_normalised_integrals)
 if wv_detrange is not None:
     wv_normt = CropWorkspace(wv_normt, XMin=wv_detrange[0], Xmax=wv_detrange[1])

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -1,0 +1,52 @@
+from mantid.simpleapi import *
+from mantid.api import AnalysisDataService as ADS
+import numpy as np
+import re, os, h5py
+
+#========================================================
+# Functions to copy instrument info needed by HORACE
+# Resolution convolution if it exists in the raw file
+def get_raw_file_from_ws(ws):
+    for alg in [h for h in ws.getHistory().getAlgorithmHistories() if 'Load' in h.name()]:
+        for prp in [a for a in alg.getProperties() if 'Filename' in a.name()]:
+            if re.search('[0-9]*.nxs', prp.value()) is not None:
+                return prp.value()
+    raise RuntimeError('Could not find raw NeXus file in workspace history')
+
+def copy_inst_info(outfile, in_ws):
+    try:
+        raw_file_name = get_raw_file_from_ws(mtd[in_ws])
+    except RuntimeError:
+        return
+    print(raw_file_name)
+    if not os.path.exists(outfile):
+        outfile = os.path.join(mantid.simpleapi.config['defaultsave.directory'], os.path.basename(outfile))
+    print(outfile)
+    with h5py.File(raw_file_name, 'r') as raw:
+        exclude = ['dae', 'detector_1', 'name']
+        to_copy = [k for k in raw['/raw_data_1/instrument'] if not any([x in k for x in exclude])]
+        if 'aperture' not in to_copy and 'mono_chopper' not in to_copy:
+            return
+        with h5py.File(outfile, 'r+') as spe:
+            print(spe.keys())
+            spe_root = list(spe.keys())[0]
+            en0 = spe[f'{spe_root}/instrument/fermi/energy'][()]
+            if 'fermi' in to_copy:
+                del spe[f'{spe_root}/instrument/fermi']
+            for grp in to_copy:
+                print(grp)
+                src = raw[f'/raw_data_1/instrument/{grp}']
+                h5py.Group.copy(src, src, spe[f'{spe_root}/instrument/'])
+            if 'fermi' in to_copy:
+                spe[f'{spe_root}/instrument/fermi/energy'][()] = en0
+            detroot = f'{spe_root}/instrument/detector_elements_1'
+            spe.create_group(detroot)
+            for df0, df1 in zip(['SPEC', 'UDET', 'DELT', 'LEN2', 'CODE', 'TTHE', 'UT01'], \
+                ['spectrum_number', 'detector_number', 'delt', 'distance', 'detector_code', 'polar_angle', 'azimuthal_angle']):
+                src = raw[f'/raw_data_1/isis_vms_compat/{df0}']
+                h5py.Group.copy(src, src, spe[detroot], df1)
+            for nn in range(raw['/raw_data_1/isis_vms_compat/NUSE'][0]):
+                src = raw[f'/raw_data_1/isis_vms_compat/UT{nn+1:02d}']
+                h5py.Group.copy(src, src, spe[detroot], f'user_table{nn+1:02d}')
+#========================================================
+

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -4,6 +4,47 @@ import numpy as np
 import re, os, h5py
 
 #========================================================
+# General utility functions
+
+def rename_existing_ws(ws_name):
+    # Gets an existing workspace and ensures we have its monitors for reduction
+    ws = CloneWorkspace(ws_name, OutputWorkspace='ws')
+    try:
+        mon_ws = ws.getMonitorWorkspace()
+    except RuntimeError:
+        specInfo = ws.spectrumInfo()
+        try:
+            mon_list = [i for i in range(ws.getNumberHistograms()) if specInfo.isMonitor(i)]
+        except RuntimeError:
+            mon_list = []
+        if len(mon_list) > 0:
+            ExtractMonitors(ws_name, DetectorWorkspace='ws', MonitorWorkspace='ws_monitors')
+        else:
+            _get_mon_from_history(ws_name)
+    else:
+        CloneWorkspace(mon_ws, OutputWorkspace='ws_monitors')
+
+def _get_mon_from_history(ws_name):
+    # Tries to look in the history of a workspace for its original raw file
+    # loads the monitors from that raw file.
+    orig_file = None
+    for hist in mtd[ws_name].getHistory().getAlgorithmHistories():
+        if hist.name().startswith('Load') and 'Filename' in [pp.name() for pp in hist.getProperties()]:
+            orig_file = hist.getPropertyValue('Filename')
+            break
+    if orig_file is None:
+        raise RuntimeError(f'Cannot find original file from workspace {ws_name} to load logs from')
+    try:
+        Load(orig_file, SpectrumMax=10, LoadMonitors=True, OutputWorkspace='tmp_mons')
+    except TypeError:
+        Load(orig_file, SpectrumMax=10, LoadMonitors='Separate', OutputWorkspace='tmp_mons')
+    ws_mon_name = f'{ws_name}_monitors'
+    RenameWorkspace('tmp_mons_monitors', ws_mon_name)
+    DeleteWorkspace('tmp_mons')
+    mtd[ws_name].setMonitorWorkspace(mtd[ws_mon_name])
+    CloneWorkspace(ws_mon_name, OutputWorkspace='ws_monitors')
+
+#========================================================
 # Functions to copy instrument info needed by HORACE
 # Resolution convolution if it exists in the raw file
 def get_raw_file_from_ws(ws):
@@ -48,5 +89,29 @@ def copy_inst_info(outfile, in_ws):
             for nn in range(raw['/raw_data_1/isis_vms_compat/NUSE'][0]):
                 src = raw[f'/raw_data_1/isis_vms_compat/UT{nn+1:02d}']
                 h5py.Group.copy(src, src, spe[detroot], f'user_table{nn+1:02d}')
-#========================================================
 
+#========================================================
+# MARI specific functions
+
+def remove_extra_spectra_if_mari(wsname='ws'):
+    ws = mtd[wsname]
+    if ws.getNumberHistograms() > 918:
+        ws = RemoveSpectra(ws, [0])
+    try:
+        ws_mon = ws.getMonitorWorkspace()
+    except RuntimeError:
+        ws_mon = mtd[f'{wsname}_monitors']
+    if ws_mon.getNumberHistograms() > 3:
+        ws_monitors = RemoveSpectra(ws_mon, [3])
+
+def shift_frame_for_mari_lowE(origEi, wsname='ws_norm', wsmon='ws_monitors'):
+    ws_norm, ws_monitors = (mtd[wsname], mtd[wsmon])
+    if origEi < 4.01:
+        # If Ei < 4, mon 3 is in 2nd frame so need to shift it by 20ms
+        ws_monitors = ScaleX(wsmon, 20000, Operation='Add', IndexMin=2, IndexMax=2, OutputWorkspace=wsmon)
+        if origEi < 3.1:
+            # Additionally if Ei<3.1, data will also be in 2nd frame, shift all ToF by 20ms
+            ws_norm = ScaleX(wsname, 20000, Operation='Add', IndexMin=0, IndexMax=ws_norm.getNumberHistograms()-1, OutputWorkspace=wsname)
+    return ws_norm, ws_monitors
+
+#========================================================

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -67,6 +67,7 @@ class DGReductionTest(unittest.TestCase):
         #Load automatically calls `LoadNeXus` first which chokes on the file...
         #ws = s_api.Load(os.path.join(self.outputpath, 'MAR28581_180meV.nxspe'))
 
+
     def test_MARI_multiple_lowE(self):
         subsdict = {'\nconfig':'\n#config',
                     'save_dir = ':'save_dir = None #',
@@ -85,6 +86,7 @@ class DGReductionTest(unittest.TestCase):
         import mari_reduction_lowE
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAR28727_1.84meV.nxspe')))
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAR28727_1.1meV.nxspe')))
+
 
     def test_existing_workspace(self):
         subsdict = {'\nconfig':'\n#config',
@@ -134,6 +136,27 @@ class DGReductionTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'LET93338_1.77meV_red.nxs')))
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'LET93338_1.03meV_red.nxs')))
         ws = s_api.Load(os.path.join(self.outputpath, 'LET93338_3.7meV_red.nxs'))
+
+
+    def test_LET_same_angle(self):
+        subsdict = {'\nconfig':'\n#config',
+                    'save_dir = ':'save_dir = None #',
+                    'INSTRUMENT_NAME':'LET',
+                    'MASK_FILE_XML':'LET_mask_222.xml',
+                    'RINGS_MAP_XML':'LET_rings_222.xml',
+                    'whitevan\s*=\s*[0-9]*':'whitevan = 91329',
+                    'sample\s*=\s*\\[*[\\]0-9,]+':'sample = [92089, 92168]',
+                    'sample_bg\s*=\s*\\[*[\\]0-9,]+':'sample_bg = None',
+                    'wv_file\s*=\s*[\\\'A-z0-9\\.]*':'wv_file = \'WV_91329.txt\'',
+                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]*':'Ei_list = [3.7]',
+                    'powder\s*=\s*True': 'powder = False'}
+        s_api.config['default.instrument'] = 'LET'
+        infile = os.path.join(self.scriptpath, 'DG_reduction.py')
+        outfile = os.path.join(self.outputpath, 'let_reduction_angle.py')
+        self.substitute_file(infile, outfile, subsdict)
+        import let_reduction_angle
+        self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'LET92089_3.7meV_1to1.nxspe')))
+        self.assertFalse(os.path.exists(os.path.join(self.outputpath, 'LET92168_3.7meV_1to1.nxspe')))
 
 
     def test_MERLIN(self):

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -16,6 +16,7 @@ class DGReductionTest(unittest.TestCase):
         cls.instpath = os.path.join(cls.repopath, 'InstrumentFiles')
         cls.outputpath = os.path.join(cls.repopath, 'tests')
         sys.path.append(cls.outputpath)
+        sys.path.append(cls.scriptpath)
         s_api.config['defaultsave.directory'] = cls.outputpath
         s_api.config.appendDataSearchDir(cls.datapath)
         for inst in ['let', 'maps', 'mari', 'merlin']:
@@ -63,6 +64,8 @@ class DGReductionTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAR28581_180meV.nxspe')))
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAR28581_29.8meV.nxspe')))
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAR28581_11.7meV.nxspe')))
+        #Load automatically calls `LoadNeXus` first which chokes on the file...
+        #ws = s_api.Load(os.path.join(self.outputpath, 'MAR28581_180meV.nxspe'))
 
 
     def test_LET_QENS(self):
@@ -91,6 +94,7 @@ class DGReductionTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'LET93338_3.7meV_red.nxs')))
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'LET93338_1.77meV_red.nxs')))
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'LET93338_1.03meV_red.nxs')))
+        ws = s_api.Load(os.path.join(self.outputpath, 'LET93338_3.7meV_red.nxs'))
 
 
     def test_MERLIN(self):
@@ -117,6 +121,7 @@ class DGReductionTest(unittest.TestCase):
         self.substitute_file(infile, outfile, subsdict)
         import merlin_reduction
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MER59151_150meV_powder.nxspe')))
+        ws = s_api.Load(os.path.join(self.outputpath, 'MER59151_150meV_powder.nxspe'))
 
 
     def test_MAPS(self):
@@ -144,6 +149,7 @@ class DGReductionTest(unittest.TestCase):
         self.substitute_file(infile, outfile, subsdict)
         import maps_reduction
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAP41335_80meV_1to1.nxspe')))
+        ws = s_api.Load(os.path.join(self.outputpath, 'MAP41335_80meV_1to1.nxspe'))
 
 
 if __name__ == '__main__':

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -67,6 +67,45 @@ class DGReductionTest(unittest.TestCase):
         #Load automatically calls `LoadNeXus` first which chokes on the file...
         #ws = s_api.Load(os.path.join(self.outputpath, 'MAR28581_180meV.nxspe'))
 
+    def test_MARI_multiple_lowE(self):
+        subsdict = {'\nconfig':'\n#config',
+                    'save_dir = ':'save_dir = None #',
+                    'INSTRUMENT_NAME':'MARI',
+                    'MASK_FILE_XML':'mari_mask2023_1.xml',
+                    'RINGS_MAP_XML':'mari_res2013.map',
+                    'whitevan\s*=\s*[0-9]*':'whitevan = 28580',
+                    'sample\s*=\s*\\[*[\\]0-9,]+':'sample = [28727, 28728]',
+                    'sample_bg\s*=\s*\\[*[\\]0-9,]+':'sample_bg = None',
+                    'wv_file\s*=\s*[\\\'A-z0-9\\.]*':'wv_file = \'WV_28580.txt\'',
+                    'wv_detrange\s*=\s*[\\[\\]0-9,]*':'wv_detrange = None',
+                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]*':'Ei_list = [1.84, 1.1]'}
+        infile = os.path.join(self.scriptpath, 'DG_reduction.py')
+        outfile = os.path.join(self.outputpath, 'mari_reduction_lowE.py')
+        self.substitute_file(infile, outfile, subsdict)
+        import mari_reduction_lowE
+        self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAR28727_1.84meV.nxspe')))
+        self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAR28727_1.1meV.nxspe')))
+
+    def test_existing_workspace(self):
+        subsdict = {'\nconfig':'\n#config',
+                    'save_dir = ':'save_dir = None #',
+                    'INSTRUMENT_NAME':'MARI',
+                    'MASK_FILE_XML':'mari_mask2023_1.xml',
+                    'RINGS_MAP_XML':'mari_res2013.map',
+                    'whitevan\s*=\s*[0-9]*':'whitevan = 28580',
+                    'sample\s*=\s*\\[*[\\]0-9,]+':'sample = ["ws_existing"]',
+                    'sample_bg\s*=\s*\\[*[\\]0-9,]+':'sample_bg = None',
+                    'wv_file\s*=\s*[\\\'A-z0-9\\.]*':'wv_file = \'WV_28580.txt\'',
+                    'wv_detrange\s*=\s*[\\[\\]0-9,]*':'wv_detrange = None',
+                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]*':'Ei_list = [1.84, 1.1]'}
+        ws_existing = s_api.Load('MAR28728.raw', LoadMonitors='Exclude')
+        ws_existing = s_api.RemoveSpectra(ws_existing, [0])
+        infile = os.path.join(self.scriptpath, 'DG_reduction.py')
+        outfile = os.path.join(self.outputpath, 'mari_reduction_existing.py')
+        self.substitute_file(infile, outfile, subsdict)
+        import mari_reduction_existing
+        self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAR28728_1.84meV.nxspe')))
+        self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAR28728_1.1meV.nxspe')))
 
     def test_LET_QENS(self):
         # Checks that the reduction script runs for LET QENS and generates output files


### PR DESCRIPTION
Various bugfixes and requested features from user cycle 23/2

* Fix checking for autoconversion of `sample` / `sample_bg` to list
* Add `theta_range` for QENS
* Fix handling errors in the instrument copying routines.
* Removed option to mask in white van runs (not necessary)
* Refactor utility/subsidiary functions into separate file (it should live in the [InstrumentFiles repo](https://github.com/pace-neutrons/InstrumentFiles/))
* Fix `sumruns` bug for MARI due to extra monitor in event files
* Add feature: low Ei (frame-shift) handling in MARI
* Add feature: option to combine "horace" scan runs with same angle