### PR TITLE
Cycle 23/3 fixes and new features for 23/4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           path: |
             InstrumentFiles
-            datafiles
+            direct_reduction_test
           key: cached-data-${{ hashFiles('**/cached_git_hashes') }}
 
       - name: Install Mantid
@@ -58,14 +58,13 @@ jobs:
         run: |
           git clone https://github.com/pace-neutrons/InstrumentFiles.git
           git clone https://github.com/mducle/direct_reduction_test.git
-          cp -rpa direct_reduction_test/datafiles ./
 
       - name: Update data instrument files
         run: |
           cwd=$(pwd)
-          cd $cwd/InstrumentFiles && git pull && git rev-parse --short HEAD > ../datafiles/cached_git_hashes
+          cd $cwd/InstrumentFiles && git pull && git rev-parse --short HEAD > ../direct_reduction_test/cached_git_hashes
           cd $cwd/direct_reduction_test && git pull && git rev-parse --short HEAD >> cached_git_hashes
-          cd $cwd && rsync -av direct_reduction_test/datafiles/ datafiles/
+          cd $cwd && cp -rpa direct_reduction_test/datafiles ./
 
       - name: Run Tests and Coverage
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,15 +34,11 @@ jobs:
       #    key: mamba-${{ hashFiles('environment.yml') }}
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: mamba-org/setup-micromamba@v1
         with:
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          activate-environment: direct-env
           environment-file: environment.yml
-          python-version: 3.8
-          auto-activate-base: false
-          use-only-tar-bz2: true
+          create-args: >-
+            python=3.10
 
       - name: Cache data and instrument files
         id: cache-files
@@ -55,7 +51,7 @@ jobs:
 
       - name: Install Mantid
         run: |
-          mamba install -c mantid/label/nightly mantid
+          micromamba install -c mantid/label/nightly mantid
 
       - name: Clone data instrument files
         if: ${{ steps.cache-files.outputs.cache-hit != 'true' }}

--- a/reduction_files/DG_monovan.py
+++ b/reduction_files/DG_monovan.py
@@ -20,6 +20,7 @@ import time
 
 t = time.time()         #start the clock
 
+#!begin_params
 #============================User Input===========================
 # Assumes that the thickness of the vanadium and the sample are the same
 monovan       = 59138                       #mono van run
@@ -37,22 +38,35 @@ wv_file       = 'WV_57083.txt'              #whitevan integrals file
 # MAPS monitors:    m2spec=41475, m3spec=41476 - fixei = False
 # LET monitors:     m2spec=98310, m3spec= None - fixei = True
 
-config['default.instrument'] = 'INSTRUMENT_NAME'
+inst = 'INSTRUMENT_NAME'
 cycle = 'CYCLE_ID'
-m2spec  = 69636                 #specID of monitor2 (post monochromator)
-m3spec  = 69640                 #specID of monitor2 (post monochromator)
 fixei   = False                 #true for LET since no m3
 powdermap = 'RINGS_MAP_XML'     #rings mapping file
 monovan_range = 0.1             #integration range (+/- fraction of Ei)
 min_theta = 5.                  #minimum theta to avoid low Q detectors (SANS)
 idebug  = False                 #keep workspaces
 #=================================================================
-inst = config['default.instrument']
+#!end_params
 
+config['default.instrument'] = inst
 if inst == 'MARI':
     source = 'Moderator'
-else:
+    m2spec = 2                  # specID of monitor2 (pre-sample)
+    m3spec = 3                  # specID of monitor3 (post-sample)
+elif inst == 'MERLIN':
     source = 'undulator'
+    m2spec = 69636              # specID of monitor2 (pre-sample)
+    m3spec = 69640              # specID of monitor3 (post-sample)
+elif inst == 'MAPS':
+    source = 'undulator'
+    m2spec = 36867              # specID of monitor2 (pre-sample)
+    m3spec = 36868              # specID of monitor3 (post-sample)
+elif inst == 'LET':
+    source = 'undulator'
+    m2spec = 98310              # specID of monitor2 (pre-sample)
+    m3spec = None               # specID of monitor3 (post-sample)
+else:
+    raise RuntimeError(f'Unrecognised instrument: {inst}')
 
 if cycle.startswith('20'):
     cycle = cycle[2:]

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -111,6 +111,9 @@ except ImportError:
     utils_loaded = False
     def rename_existing_ws(*a, **k): raise RuntimeError('Unable to load utils')
     def remove_extra_spectra_if_mari(*a, **k): raise RuntimeError('Unable to load utils')
+    def autoei(*a, **k):
+        raise RuntimeError('Cannot use Auto-Ei: ' \
+            'You need to copy the reduction_utils.py file somewhere on the Python path')
 
 #========================================================
 # Helper functions

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -17,6 +17,7 @@
 # import mantid algorithms, numpy and matplotlib
 from mantid.simpleapi import *
 from mantid.api import AnalysisDataService as ADS
+from mantid.kernel.funcinspect import lhs_info
 import numpy as np
 import os, sys
 import time
@@ -60,6 +61,8 @@ idebug = False                  # keep workspaces and check absolute units on el
 save_dir = f'/instrument/{inst}/RBNumber/USER_RB_FOLDER'  # Set to None to avoid reseting
 psi_motor_name = 'rot'          # name of the rotation motor in the logs
 angles_workspace = 'angles_ws'  # name of workspace to store previously seen angles
+sumruns_savemem = False         # Compresses event in summed ws to save memory
+                                # (causes some loss of data so cannot use event filtering)
 #========================================================
 
 # ==============================setup directroties================================
@@ -139,6 +142,12 @@ def load_sum(run_list):
             w_buf = Plus('w_buf', 'ws')
             w_buf_monitors = Plus('w_buf_monitors', 'ws_monitors')
             print(f'run #{irun} added')
+    ADS.remove('ws')
+    ADS.remove('ws_monitors')
+    wsout_name = lhs_info('names')[0]
+    RenameWorkspace('w_buf_monitors', wsout_name+'_monitors')
+    return RenameWorkspace('w_buf', wsout_name)
+
 #========================================================
 
 
@@ -196,16 +205,12 @@ else:
 
 # =======================load background runs and sum=========================
 if sample_bg is not None:
-    load_sum(sample_bg)
-    ws_bg = CloneWorkspace('w_buf')
-    ws_bg = NormaliseByCurrent('ws_bg')
+    ws_bg = load_sum(sample_bg)
 
 # =======================sum sample runs if required=========================
 sumsuf = sumruns and len(sample) > 1
 if sumruns:
-    load_sum(sample)
-    ws = CloneWorkspace('w_buf')
-    ws_monitors = CloneWorkspace('w_buf_monitors')
+    ws = load_sum(sample)
     sample = [sample[0]]
 
 # =====================angles cache stuff====================================
@@ -236,7 +241,7 @@ for irun in sample:
         if same_angle_action.lower() != 'ignore':
             runs_with_same_angles = get_angle(irun, angles_workspace, psi_motor_name, tryload)
             if len(runs_with_same_angles) > 1:
-                load_sum(runs_with_same_angles)
+                w_buf = load_sum(runs_with_same_angles)
                 if same_angle_action.lower() == 'replace':
                     irun = runs_with_same_angles[0]
                     runs_with_angles_already_seen += runs_with_same_angles
@@ -244,6 +249,13 @@ for irun in sample:
             tryload(irun)
             print(f'Loading run# {irun}')
     ws = NormaliseByCurrent('ws')
+    if sumruns_savemem:
+        ws = CompressEvents(ws, Tolerance=1e-5)  # Tolerance in microseconds
+
+    # instrument geometry to work out ToF ranges
+    sampos = ws.getInstrument().getSample().getPos()
+    l1 = (sampos - ws.getInstrument().getSource().getPos()).norm()
+    l2 = (ws.getDetector(0).getPos() - sampos).norm()
 
 # ============================= Ei loop =====================================
     for ienergy in range(len(Ei_list)):
@@ -253,15 +265,20 @@ for irun in sample:
         mvf = mv_fac[ienergy]
         print(f'\n{inst}: Reducing data for Ei={Ei:.2f} meV')
 
-        ws_corrected = Scale('ws', 1 / tr, 'Multiply')
+        tof_min = np.sqrt(l1**2 * 5.227e6 / Ei)
+        tof_max = tof_min + np.sqrt(l2**2 * 5.226e6 / (Ei*(1-Erange[-1])))
+        ws_rep = CropWorkspace(ws, tof_min, tof_max)
+
         if sample_bg is not None:
             print(f'... subtracting background - transmission factor = {tr:.2f}')
-            ws_corrected  = ws/tr - ws_bg
+            ws_rep  = ws_rep/tr - ws_bg
+        else:
+            ws_rep = Scale('ws_rep', 1 / tr, 'Multiply')
 
         # normalise to WB vanadium and apply fixed mask
         print('... normalising/masking data')
-        ws_norm = Divide('ws_corrected', wv_file)       # white beam normalisation
-        MaskDetectors(ws_norm,MaskedWorkspace=mask,ForceInstrumentMasking=True)
+        ws_rep = Divide('ws_rep', wv_file)       # white beam normalisation
+        MaskDetectors(ws_rep, MaskedWorkspace=mask, ForceInstrumentMasking=True)
 
         # t2e section
         print('... t2e section')
@@ -272,7 +289,7 @@ for irun in sample:
 
         if inst == 'MARI' and utils_loaded and origEi < 4.01:
             # Shifts data / monitors into second frame for MARI
-            ws_norm, ws_monitors = shift_frame_for_mari_lowE(origEi, wsname='ws_norm', wsmon='ws_monitors')
+            ws_rep, ws_monitors = shift_frame_for_mari_lowE(origEi, wsname='ws_rep', wsmon='ws_monitors')
 
         # this section shifts the time-of-flight such that the monitor2 peak
         # in the current monitor workspace (post monochromator) is at t=0 and L=0
@@ -286,13 +303,14 @@ for irun in sample:
 
         print(f'... m2 tof={mon2_peak:.2f} mus, m2 pos={m2pos:.2f} m')
 
-        ws_norm = ScaleX(ws_norm, Factor=-mon2_peak, Operation='Add', InstrumentParameter='DelayTime', Combine=True)
-        MoveInstrumentComponent(ws_norm, ComponentName=source, Z=m2pos, RelativePosition=False)
+        ws_rep = ScaleX(ws_rep, Factor=-mon2_peak, Operation='Add', InstrumentParameter='DelayTime', Combine=True)
+        MoveInstrumentComponent(ws_rep, ComponentName=source, Z=m2pos, RelativePosition=False)
 
-        ws_out = ConvertUnits(ws_norm, 'DeltaE', EMode='Direct', EFixed=Ei)
-        ws_out = Rebin(ws_out, [x*origEi for x in Erange], PreserveEvents=False)
+        ws_rep = ConvertUnits(ws_rep, 'DeltaE', EMode='Direct', EFixed=Ei)
+        ws_out = Rebin(ws_rep, [x*origEi for x in Erange], PreserveEvents=False)
         ws_out = DetectorEfficiencyCor(ws_out, IncidentEnergy=Ei)
         ws_out = CorrectKiKf(ws_out, Efixed=Ei, EMode='Direct')
+        ADS.remove('ws_rep')
 
         # monovan scaling
         if mv_file is not None:

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -23,6 +23,7 @@ import os, sys
 import time
 from importlib import reload
 
+#!begin_params
 #=======================User Inputs=======================
 powder         = True                        # powder or 1to1 map
 sumruns        = False                       # set to True to sum sample runs
@@ -65,6 +66,7 @@ angles_workspace = 'angles_ws'  # name of workspace to store previously seen ang
 sumruns_savemem = False         # Compresses event in summed ws to save memory
                                 # (causes some loss of data so cannot use event filtering)
 #========================================================
+#!end_params
 
 # ==============================setup directroties================================
 config['default.instrument'] = inst

--- a/reduction_files/DG_whitevan.py
+++ b/reduction_files/DG_whitevan.py
@@ -14,6 +14,7 @@
 # import mantid algorithms, numpy and matplotlib
 from mantid.simpleapi import *
 from mantid.api import AnalysisDataService as ADS
+from mantid.kernel.funcinspect import lhs_info
 import numpy as np
 import time
 
@@ -40,28 +41,49 @@ if save_dir is not None:
 cycle_shortform = cycle[2:] if cycle.startswith('20') else cycle
 data_dir = f'/archive/NDX{inst}/Instrument/data/cycle_{cycle_shortform}/'
 config.appendDataSearchDir(data_dir)
-config.appendDataSearchDir(save_dir)
+if save_dir is not None:
+    config.appendDataSearchDir(save_dir)
 
 #========================================================
-def try_load_no_mon(irun, ws_name):
+def try_load_no_mon(irun, ws_name=None):
     # LoadISISNexus needs LoadMonitors='Exclude'
     # LoadEventNexus needs LoadMonitors=False
+    if ws_name is None:
+        nret, ws_name = lhs_info('both')
+        if nret > 1:
+            raise RuntimeError('load: Only one output workspace name can be given')
+        ws_name = ws_name[0]
     try:
         return Load(str(irun), LoadMonitors='Exclude', OutputWorkspace=ws_name)
     except ValueError:
         return Load(str(irun), LoadMonitors=False, OutputWorkspace=ws_name)
+
+def load_sum(run_list):
+    if isinstance(run_list, str) or not hasattr(run_list, '__iter__'):
+        run_list = [run_list]
+    for ii, irun in enumerate(run_list):
+        try_load_no_mon(irun, 'ws')
+        if ii == 0:
+            w_buf = CloneWorkspace('ws')
+            print(f'run #{irun} loaded')
+        else:
+            w_buf = Plus('w_buf', 'ws')
+            print(f'run #{irun} added')
+    nret, ws_name = lhs_info('both')
+    if nret == 1:
+        CloneWorkspace('w_buf', OutputWorkspace=ws_name[0])
 #========================================================
 
 print(f'\n======= {inst} white van reduction =======')
 
 # =================load white van and background and subtract=====================
-print(f'WHITE_VAN {inst}: Loading white vanadium run# {whitevan}')
-wv = try_load_no_mon(str(whitevan), 'wv')
+print(f'WHITE_VAN {inst}: Loading white vanadium run(s)')
+wv = load_sum(whitevan)
 wv = NormaliseByCurrent('wv')
 wv_corrected = Scale('wv', 1/whitevan_trans, 'Multiply')
 if (whitevan_bg is not None):
-    print(f'... subtracting white vanadium background run# {whitevan_bg}')
-    wv_bg = try_load_no_mon(str(whitevan_bg), 'wv_bg')
+    print(f'... subtracting white vanadium background run(s)')
+    wv_bg = load_sum(whitevan_bg)
     wv_bg = NormaliseByCurrent('wv_bg')
     wv_corrected = wv/whitevan_trans - wv_bg
 

--- a/reduction_files/DG_whitevan.py
+++ b/reduction_files/DG_whitevan.py
@@ -78,7 +78,8 @@ scale_factor = len(wv_normt.dataY(0)) / wv_scale.dataY(0)[0]
 WV_normalised_integrals = Scale(WV_normalised_integrals, scale_factor, 'Multiply')
 
 # ===========================output integrals file================================
-ofile = f'WV_{whitevan}.txt'
+wv_name = whitevan if (isinstance(whitevan, (str, int, float)) or len(whitevan)==1) else whitevan[0]
+ofile = f'WV_{wv_name}.txt'
 print(f'WHITE_VAN {inst}: Saving integrals in {ofile}')
 print(f'... average intensity = {1/scale_factor:.2f}')
 SaveAscii(WV_normalised_integrals, ofile)

--- a/reduction_files/DG_whitevan.py
+++ b/reduction_files/DG_whitevan.py
@@ -20,6 +20,7 @@ import time
 
 t = time.time()         #start the clock
 
+#!begin_params
 #=======================User Inputs======================
 whitevan       = 78715                  # white vanadium run
 whitevan_bg    = None                   # background for the white vanadium
@@ -34,6 +35,7 @@ wv_detrange = [30000,60000]             # spectrum index range for average inten
 idebug = False                          # keep itermediate workspaces for debugging
 save_dir = f'/instrument/{inst}/RBNumber/USER_RB_FOLDER' # Set to None to avoid resetting
 #========================================================
+#!end_params
 
 config['default.instrument'] = inst
 if save_dir is not None:

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -3,6 +3,7 @@ from mantid.api import AnalysisDataService as ADS
 import numpy as np
 import re, os, h5py
 import json
+import warnings
 
 #========================================================
 # General utility functions
@@ -156,3 +157,170 @@ def shift_frame_for_mari_lowE(origEi, wsname='ws_norm', wsmon='ws_monitors'):
     return ws_norm, ws_monitors
 
 #========================================================
+# Auto-Ei routine
+
+
+def mode(inp):
+    return max(set(inp), key=list(inp).count)
+
+
+def roundlog10(val):
+    expn = int(min(0, np.floor(np.log10(val)) - 2))
+    return np.round(val, decimals=-expn)
+
+
+def autoei(ws):
+    assert hasattr(ws, 'getInstrument') and hasattr(ws, 'getRun'), 'Input must be a Mantid workspace'
+    inst = ws.getInstrument().getName()
+    run = ws.getRun()
+
+    def getLog(logname):
+        logv = run.getProperty(logname)
+        if 'Filtered' in str(type(logv)):
+            return logv.filtered_value
+        t0 = run.startTime().to_datetime64()
+        t1 = run.endTime().to_datetime64()
+        t = logv.times
+        mask = np.logical_and(t0 <= t, t <= t1)
+        return logv.value[mask]
+
+
+    def getfracLog(logname, frac=0.25, expn=1.):
+        val = getLog(logname)
+        if expn == 1.:
+            return mode(val[int(len(val) * frac):])
+        else:
+            return mode(np.round(val[int(len(val) * frac):] * expn)) / expn
+
+
+    if inst == 'LET':
+        try:
+            c1_freq = getfracLog('Chopper1_Disk1_speed')
+        except ValueError:
+            return []
+        c5_mode = run.getProperty('Chopper5_slits').value[-1]
+        if 'open' in c5_mode.lower():    # Whitebeam mode
+            return []
+        f1, f2, c4_freq = (getfracLog(nm) for nm in ['Chopper5_Disk1_speed', 'Chopper3_speed', 'Chopper4_speed'])
+        ph1a, ph1b, ph2, ph3, ph4, ph5a, ph5b = (getfracLog(nm) for nm in ['Chopper1_Disk1_phase', 'Chopper1_Disk2_phase',
+            'Chopper2_phase', 'Chopper3_phase', 'Chopper4_phase', 'Chopper5_Disk1_phase', 'Chopper5_Disk2_phase'])
+        # Moderator Chopper distances in m
+        lm1a, lm1b, lm2, lm3, lm4, lm5a, lm5b = (7.839, 7.828, 8.4, 11.749, 15.664, 23.504, 23.496)
+        # Chopper time offsets in us
+        tc1a, tc1b, tc3, tc4 = ((slp / frq) + yc for slp, frq, yc in zip([1.3333e5, 0.7694e5, 186944, 115000], \
+            [c1_freq, c1_freq, f2, c4_freq], [7.3, 2.4, -87.2, -82.607]))
+        if 'resolution' in c5_mode.lower():
+            tc5a = (1.5631e6 / f1) + 0.70
+            tc5b = ( 1.3149e6 / f1) + 3.13
+        elif 'flux' in c5_mode.lower():
+            tc5a = (1.4520e6 / f1) + 2.56
+            tc5b = (1.1204e6 / f1) + 3.33
+        elif 'intermediate' in c5_mode.lower():
+            tc5a = (1.0630e6 / f1) + 5.88
+            tc5b = (1.8149e6 / f1) + 2.17
+        else:
+            warnings.warning(f'Unknown mode "{c5_mode}" using High Flux settings')
+            tc5a = (1.4520e6 / f1) + 2.56
+            tc5b = (1.1204e6 / f1) + 3.33
+        # Determines the allowed reps through each set of choppers
+        tfoc = 70.   # LET sets tfoc=80 for Ei<5 and 60 otherwise, we don't know which it is so use the average
+        periods = [1.e6 / nslit / frq for nslit, frq in zip([6, 2, 6, 2], [c1_freq, f2, c4_freq, f1])]
+        delays = [phase + tc - tfoc for phase, tc in zip([ph1a, ph3, ph4, ph5a], [tc1a, tc3, tc4, tc5a])]
+        # Chopper 2 is the bandwidth chopper and its phase determines the min and max ToF.
+        tf0 = 2500 if ph2 > 50000 else ph2   # Sets a minimum such that Ei~=50 is max Ei
+        tf1 = (ph2 + 27000) % 100000         # Opening width of chopper 2 is ~26ms [TODO: tune this value!]
+        def inrange(tf, l):
+            lim = [2286.26 * l / sqrte for sqrte in [2286.26 * lm2 / t for t in [tf0, tf1]]]
+            return tf >= lim[0] and tf < lim[1]
+        # Determine the reps which make it through the other choppers 1, 3, 4 and 5
+        eis, eisv = ([], [])
+        for l, d, p, in zip([lm1a, lm3, lm4, lm5a], delays, periods):
+            eisv.append(np.array([(((2286.26 * l) / tf)**2) for tf in [(d + s*p) for s in range(-30, 30)] if inrange(tf, l)]))
+        # Calculates which reps which passes Chopper 5 also make it through all the others within 5% tolerance
+        for ei in eisv[3]:
+            istrans = [np.any((np.abs(eisn - ei) / eisn) < 0.05) for eisn in eisv[:3]]
+            if all(istrans):
+                eis.append(roundlog10(ei))
+        return eis
+
+
+    elif inst == 'MARI':
+        try:
+            freq = mode(getLog('Fermi_Speed'))
+        except ValueError:
+            return []
+        ei_nominal = mode(getLog('Ei_nominal'))
+        phase1, phase2 = (mode(getLog(nam)) for nam in ['Phase_Thick_1', 'Phase_Thick_2'])
+        delay = getfracLog('Fermi_delay')
+        sqrt_ei = np.sqrt(ei_nominal)
+        lmc = 10.04   # Moderator-Fermi distance
+        period = 1.e6 / freq
+        delay_calc = ((2286.26 * lmc) / sqrt_ei)
+        t_offset_ref = {'S':2033.3/freq-5.4, 'G':1339.9/freq-7.3}
+        t_offset = delay - (delay_calc % period)
+        chopper_type = min(t_offset_ref.keys(), key=lambda x:np.abs(t_offset - t_offset_ref[x]))
+        nom_disk1, nom_disk2 = (((2286.26 * l) / sqrt_ei) - c for l, c in zip([7.861, 7.904], [5879., 6041.]))
+        delt_disk1, delt_disk2 = (ph - nom for ph, nom in zip([phase1, phase2], [nom_disk1, nom_disk2]))
+        disk_delta = delt_disk2 - delt_disk1
+        slots_delta = np.round(disk_delta / 202.11) / 10
+        assert slots_delta % 1.0 < 0.2, 'Bad slots calculation'
+        slots = {0:[0,1,2,4], 1:[0,1], 2:[0,2], 4:[0]}[abs(int(slots_delta))]
+        disk_ref = 6 - (np.round(delt_disk1 / 202.11) / 10)
+        assert disk_ref % 1.0 < 0.2, f'Bad disk calculation'
+        disk = {0:disk_ref, 1:disk_ref-1, 2:1 if disk_ref==2 else 0, 4:0}[abs(int(slots_delta))]
+        reps = [d-disk for d in slots]
+        eis_disk = {((2286.26*lmc) / (delay_calc + s*2500.))**2 for s in reps}
+        period = period / 2. if 'G' in chopper_type.upper() else period
+        eis = {((2286.26*lmc) / (delay_calc + s*period))**2 for s in range(-10, 10)}
+        inrange = lambda x: (x > 1 and x < 2.9) or (x > 4 and x < 1000)
+        return [roundlog10(ei) for ei in np.sort(list(eis.intersection(eis_disk)))[::-1] if inrange(ei)]
+
+
+    elif inst == 'MAPS':
+        try:
+            freq = mode(getLog('Fermi_Speed'))
+        except ValueError:
+            return []
+        period = 1.e6 / freq
+        delay_angle = getfracLog('Fermi_Delay', expn=10.)
+        disk_delay = mode(getLog('Disc_Delay'))
+        lmc = 10.143   # Mod-Fermi distance
+        ldc = 8.831    # Mod-Disk distance
+        pickup_position = 180.
+        t_offsets = [20000 * (slit - pickup_position) / 360. for slit in [180., -39.1, 0., 39.1]]
+        disk_eis = [((2286.372 * ldc) / tof)**2 for tof in [disk_delay + t_offset for t_offset in t_offsets] if tof > 0]
+        fermi_eis = []
+        for pickup_pos, t_off in zip([195.1, 14.429], [26.2, 24.53]):  # 'S', and 'A' chopper respectively
+            delay = period * (delay_angle - pickup_pos) / 360.
+            fermi_eis += [((2286.372 * lmc) / tf)**2 for tf in [(delay + s*period) for s in range(-10, 10)] if tf > 100 and tf < 12000]
+        fermi_eis = np.array(fermi_eis)
+        eis = []
+        for ei in disk_eis:
+            ed = np.abs(fermi_eis - ei) / fermi_eis
+            if np.any(ed < 0.1):
+                eis.append(roundlog10(ei))
+        return eis
+
+
+    elif inst == 'MERLIN':
+        run = ws.getRun()
+        try:
+            freq = mode(getLog('Chopper_Speed'))
+        except ValueError:
+            return []
+        delay = getfracLog('Chopper_Delay')
+        disk_delay = mode(getLog('Disc_Delay'))
+        rrm_mode = np.abs(disk_delay - 13700) < 10 or np.abs(disk_delay - 12400) < 10
+        lmc = 9.995    # Mod-Fermi distance
+        ldc = 9.2176   # Mod-Disk distance
+        if not rrm_mode:
+            return [roundlog10(((2286.26*ldc) / disk_delay)**2)]
+        else:          # Assume using Gd chopper (t_offset = 2000/freq-5, for 'S' it is 300/freq-8)
+            period = 20000 * (25. / freq)
+            tof = (2286.26 * lmc) / np.sqrt(roundlog10(((2286.26 * lmc) / (delay - 2000/freq - 2))**2))
+            tfmx = 7500 if np.abs(disk_delay - 12400) < 10 else 8500
+            return [roundlog10(((2286.26*lmc) / tf)**2) for tf in [(tof + s*period) for s in range(-10, 10)] if tf > 1500 and tf < tfmx]
+
+
+    else:
+        raise RuntimeError(f'Instrument {inst} not supported')

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -381,28 +381,27 @@ class DG_reduction_wrapper:
         env.update(kwargs)
         exec(code, env)
 
-def run_reduction(**kwargs):
+def run_reduction(mod='reduction', **kwargs):
     global _DGRED
     if _DGRED is None:
         _DGRED = DG_reduction_wrapper()
-    _DGRED(**kwargs)
+    if 'inst' in kwargs:
+        config['default.instrument'] = kwargs['inst']
+    _DGRED(mod=mod, **kwargs)
 
 def run_whitevan(**kwargs):
-    global _DGRED
-    if _DGRED is None:
-        _DGRED = DG_reduction_wrapper()
-    _DGRED(mod='whitevan', **kwargs)
+    run_reduction(mod='whitevan', **kwargs)
 
 def run_monovan(**kwargs):
-    global _DGRED
-    if _DGRED is None:
-        _DGRED = DG_reduction_wrapper()
-    _DGRED(mod='monovan', **kwargs)
+    run_reduction(mod='monovan', **kwargs)
 
 def iliad(runno, ei, wbvan, monovan=None, sam_mass=None, sam_rmm=None, sum_runs=False, **kwargs):
     wv_name = wbvan if (isinstance(wbvan, (str, int, float)) or len(wbvan)==1) else wbvan[0]
     wv_file = f'WV_{wv_name}.txt'
-    wv_args = {'inst':kwargs['inst']} if 'inst' in kwargs else {}
+    wv_args = {}
+    if 'inst' in kwargs:
+        config['default.instrument'] = kwargs['inst']
+        wv_args = {'inst':kwargs['inst']}
     try:
         LoadAscii(wv_file, OutputWorkspace=wv_file)
     except ValueError:

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -4,6 +4,7 @@ import numpy as np
 import os, sys, re
 import mantid.simpleapi as s_api
 from os.path import abspath, dirname
+from mantid.simpleapi import LoadNexusProcessed
 
 class DGReductionTest(unittest.TestCase):
 
@@ -50,7 +51,7 @@ class DGReductionTest(unittest.TestCase):
                     'sample_bg\s*=\s*\\[*[\\]0-9,]+':'sample_bg = None',
                     'wv_file\s*=\s*[\\\'A-z0-9\\.]*':'wv_file = \'WV_28580.txt\'',
                     'wv_detrange\s*=\s*[\\[\\]0-9,]*':'wv_detrange = None',
-                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]*':'Ei_list = [180, 29.8, 11.7]'}
+                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]+.*':'Ei_list = [180, 29.8, 11.7]'}
         s_api.config['default.instrument'] = 'MARI'
         infile = os.path.join(self.scriptpath, 'DG_whitevan.py')
         outfile = os.path.join(self.outputpath, 'mari_whitevan.py')
@@ -79,7 +80,7 @@ class DGReductionTest(unittest.TestCase):
                     'sample_bg\s*=\s*\\[*[\\]0-9,]+':'sample_bg = None',
                     'wv_file\s*=\s*[\\\'A-z0-9\\.]*':'wv_file = \'WV_28580.txt\'',
                     'wv_detrange\s*=\s*[\\[\\]0-9,]*':'wv_detrange = None',
-                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]*':'Ei_list = [1.84, 1.1]'}
+                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]+.*':'Ei_list = [1.84, 1.1]'}
         infile = os.path.join(self.scriptpath, 'DG_reduction.py')
         outfile = os.path.join(self.outputpath, 'mari_reduction_lowE.py')
         self.substitute_file(infile, outfile, subsdict)
@@ -99,15 +100,15 @@ class DGReductionTest(unittest.TestCase):
                     'sample_bg\s*=\s*\\[*[\\]0-9,]+':'sample_bg = None',
                     'wv_file\s*=\s*[\\\'A-z0-9\\.]*':'wv_file = \'WV_28580.txt\'',
                     'wv_detrange\s*=\s*[\\[\\]0-9,]*':'wv_detrange = None',
-                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]*':'Ei_list = [1.84, 1.1]'}
+                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]+.*':'Ei_list = [1.84, 1.1]'}
         ws_existing = s_api.Load('MAR28728.raw', LoadMonitors='Exclude')
         ws_existing = s_api.RemoveSpectra(ws_existing, [0])
         infile = os.path.join(self.scriptpath, 'DG_reduction.py')
         outfile = os.path.join(self.outputpath, 'mari_reduction_existing.py')
         self.substitute_file(infile, outfile, subsdict)
         import mari_reduction_existing
-        self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAR28728_1.84meV.nxspe')))
-        self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAR28728_1.1meV.nxspe')))
+        self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MARws_existing_1.84meV.nxspe')))
+        self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MARws_existing_1.1meV.nxspe')))
 
     def test_LET_QENS(self):
         # Checks that the reduction script runs for LET QENS and generates output files
@@ -120,7 +121,7 @@ class DGReductionTest(unittest.TestCase):
                     'sample\s*=\s*\\[*[\\]0-9,]+':'sample = 93338',
                     'sample_bg\s*=\s*\\[*[\\]0-9,]+':'sample_bg = 93329',
                     'wv_file\s*=\s*[\\\'A-z0-9\\.]*':'wv_file = \'WV_91329.txt\'',
-                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]*':'Ei_list = [3.7, 1.77, 1.03]',
+                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]+.*':'Ei_list = [3.7, 1.77, 1.03]',
                     'QENS = False':'QENS = True'}
         s_api.config['default.instrument'] = 'LET'
         infile = os.path.join(self.scriptpath, 'DG_whitevan.py')
@@ -148,15 +149,22 @@ class DGReductionTest(unittest.TestCase):
                     'sample\s*=\s*\\[*[\\]0-9,]+':'sample = [92089, 92168]',
                     'sample_bg\s*=\s*\\[*[\\]0-9,]+':'sample_bg = None',
                     'wv_file\s*=\s*[\\\'A-z0-9\\.]*':'wv_file = \'WV_91329.txt\'',
-                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]*':'Ei_list = [3.7]',
-                    'powder\s*=\s*True': 'powder = False'}
+                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]+.*':'Ei_list = [3.7]',
+                    'powder\s*=\s*True': 'powder = False',
+                    "saveformat = '.nxspe'":"saveformat = '.nxs'",
+                    "same_angle_action = 'ignore'":"same_angle_action = 'replace'"}
         s_api.config['default.instrument'] = 'LET'
         infile = os.path.join(self.scriptpath, 'DG_reduction.py')
         outfile = os.path.join(self.outputpath, 'let_reduction_angle.py')
         self.substitute_file(infile, outfile, subsdict)
         import let_reduction_angle
-        self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'LET92089_3.7meV_1to1.nxspe')))
-        self.assertFalse(os.path.exists(os.path.join(self.outputpath, 'LET92168_3.7meV_1to1.nxspe')))
+        self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'LET92089_3.7meV_1to1.nxs')))
+        self.assertFalse(os.path.exists(os.path.join(self.outputpath, 'LET92168_3.7meV_1to1.nxs')))
+        ws_out = LoadNexusProcessed(os.path.join(self.outputpath, 'LET92089_3.7meV_1to1.nxs'))
+        algs = {f'{h.name()}_{ii}':h.getProperties() for ii, h in enumerate(ws_out.getHistory().getAlgorithmHistories())}
+        self.assertTrue('Plus' in [v.split('_')[0] for v in algs.keys()])
+        loaded_files = [p.value() for al, pp in algs.items() if 'Load' in al for p in pp if p.name() == 'Filename']
+        self.assertTrue(any(['92089' in v for v in loaded_files]) and any(['92168' in v for v in loaded_files]))
 
 
     def test_MERLIN(self):
@@ -170,7 +178,7 @@ class DGReductionTest(unittest.TestCase):
                     'sample\s*=\s*\\[*[\\]0-9,]+':'sample = 59151',
                     'sample_bg\s*=\s*\\[*[\\]0-9,]+':'sample_bg = None',
                     'wv_file\s*=\s*[\\\'A-z0-9\\.]*':'wv_file = \'WV_57088.txt\'',
-                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]*':'Ei_list = [150]',
+                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]+.*':'Ei_list = [150]',
                     'fixei = True':'fixei = False'}
         s_api.config['default.instrument'] = 'MERLIN'
         infile = os.path.join(self.scriptpath, 'DG_whitevan.py')
@@ -197,9 +205,11 @@ class DGReductionTest(unittest.TestCase):
                     'sample\s*=\s*\\[*[\\]0-9,]+':'sample = 41335',
                     'sample_bg\s*=\s*\\[*[\\]0-9,]+':'sample_bg = None',
                     'wv_file\s*=\s*[\\\'A-z0-9\\.]*':'wv_file = \'WV_41272.txt\'',
-                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]*':'Ei_list = [80]',
+                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]+.*':'Ei_list = [80]',
                     'fixei = True':'fixei = False',
-                    'powder\s*=\s*True':'powder = False'}
+                    'powder\s*=\s*True':'powder = False',
+                    'm2spec = 36867':'m2spec = 41475',
+                    'm3spec = 36868':'m3spec = 41476'}
         s_api.config['default.instrument'] = 'MAPS'
         infile = os.path.join(self.scriptpath, 'DG_whitevan.py')
         outfile = os.path.join(self.outputpath, 'maps_whitevan.py')
@@ -212,6 +222,18 @@ class DGReductionTest(unittest.TestCase):
         import maps_reduction
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MAP41335_80meV_1to1.nxspe')))
         ws = s_api.Load(os.path.join(self.outputpath, 'MAP41335_80meV_1to1.nxspe'))
+
+
+    def test_auto_iliad(self):
+        # Tests that the iliad driver script with Ei='auto' works
+        sys.path.append(self.scriptpath)
+        wv_file = os.path.join(self.outputpath, 'WV_28580.txt')
+        if os.path.exists(wv_file):
+            os.remove(wv_file)
+        s_api.config['default.instrument'] = 'MARI'
+        from reduction_utils import iliad
+        iliad(28581, ei='auto', wbvan=28580, inst='MARI', hard_mask_file='mari_mask2023_1.xml',
+              powdermap='mari_res2013.map')
 
 
 if __name__ == '__main__':

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -110,6 +110,7 @@ class DGReductionTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MARws_existing_1.84meV.nxspe')))
         self.assertTrue(os.path.exists(os.path.join(self.outputpath, 'MARws_existing_1.1meV.nxspe')))
 
+
     def test_LET_QENS(self):
         # Checks that the reduction script runs for LET QENS and generates output files
         subsdict = {'\nconfig':'\n#config',
@@ -230,11 +231,19 @@ class DGReductionTest(unittest.TestCase):
         wv_file = os.path.join(self.outputpath, 'WV_28580.txt')
         if os.path.exists(wv_file):
             os.remove(wv_file)
-        s_api.config['default.instrument'] = 'MARI'
         from reduction_utils import iliad
         iliad(28581, ei='auto', wbvan=28580, inst='MARI', hard_mask_file='mari_mask2023_1.xml',
               powdermap='mari_res2013.map')
 
+
+    def test_func_continuous(self):
+        from reduction_utils import run_reduction
+        run_reduction(sample=[97138, 97139], Ei_list=[1.7], sumruns=True, wv_file='WV_91329.txt', 
+                      inst='LET', mask='LET_mask_222.xml', powdermap='LET_rings_222.xml',
+                      cs_block='T_Stick', cs_block_unit='K', cs_bin_size=10)
+        for tt in np.arange(197.9, 288, 10):
+            self.assertTrue(os.path.exists(os.path.join(self.outputpath, f'LET97138_1.7meV_{tt}K_powder.nxspe')))
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Various bugfixes identified during cycle 23/3:

* Rebinning in energy now uses the Ei defined in `Ei_list` by user instead of the Ei found by `GetEi` - this ensures that files with the same nominal Ei can be subtracted
* Fixed name error when `whitevan` is a list (for summed white-vans)
* Remove extraneous events logs in output `nxs` to reduce file size (is now comparable to `nxspe` in size for powders - around 2-3MB).
* Reduce memory use by removing temporary workspaces (`ws_norm`, `ws_corrected`, `ws_out`) which are essentially clones/copies of the full event workspace. For each rep a single temporary workspace (`ws_rep`) is created by cropping to the relevant ToF region (defined by `Erange`) and operated upon.
* Add routines specifically for MARI to handle high background at high angles due to shielding mechanical failure affecting cycles 23/3 and 23/4 (at least).

New features implemented for cycle 23/4:

* Automatic Ei determination from chopper phases. Now users can set `Ei_list = 'auto'` to use the auto-Ei feature.
* Continous scans: If given a single run or a list with `sumruns=True` will split this into multiple reduced files based on a log block value (e.g. split into different angles for Horace or temperatures, fields, etc. in a sweep). Enabled by setting `cs_block` to the name of a valid log block, and `cs_bin_size` to non-zero. Must have `same_angle_action='ignore'`.
* `iliad` function driver for people who don't want to run through the file. This is used as follows:

```
from reduction_utils import iliad
iliad(runno=28581, ei='auto', wbvan=28580)
```

This actually uses the `DG_*` scripts in the same directory (presumably the user's RB folder) so if you've changed anything in those files, they will be used by the `iliad` function. As `iliad` reads the `DG_*` script there are now markers `#!begin_params` and `#!end_params` which must be kept in the file to let `iliad` know what are parameters. It will use the values in the `DG_*` files as default but you can override any parameter by specifying it as a keyword argument to iliad. The exceptions are:

* `runno` is used instead of `sample`
* `ei` is used instead of `Ei_list`
* `wbvan` is used instead of `whitevan`
* `sam_mass` is used instead of `sample_mass`
* `sam_rmm` is used instead of `sample_fwt`

This is to ensure compatibility with the old `iliad` scripts. In addition the old parameters `hard_mask_file` and `sum_runs` will be recognised and interpreted as `mask` and `sumruns` in the new scripts.
