### PR TITLE
Cycle 23/5 bugfixes and instrument info update

### DIFF
--- a/reduction_files/DG_monovan.py
+++ b/reduction_files/DG_monovan.py
@@ -129,11 +129,14 @@ for ienergy in range(len(Ei_list)):
 # in the current monitor workspace (post monochromator) is at t=0 and L=0
 # note that the offest is not the predicted value due to energy dependence of the source position
 
+    Ei_orig = Ei
     if m3spec is not None and not fixei:
-        (Ei,mon2_peak,_,_) = GetEi(mv_monitors,Monitor1Spec=m2spec,Monitor2Spec=m3spec,EnergyEstimate=Ei)
+        (Ei,mon2_peak,_,_) = GetEi(mv_monitors,Monitor1Spec=m2spec,Monitor2Spec=m3spec,EnergyEstimate=Ei,FixEi=fixei)
         print("... refined Ei=%.2f meV" % Ei)
     else:
         (Ei,mon2_peak,_,_) = GetEi(mv_monitors,Monitor2Spec=m2spec,EnergyEstimate=Ei,FixEi=fixei)
+    if np.isnan(Ei):
+        Ei = Ei_orig
     print("... m2 tof=%.2f mus, m2 pos=%.2f m" % (mon2_peak,m2pos))
 
     mv_norm = ScaleX(mv_norm, Factor=-mon2_peak, Operation='Add', InstrumentParameter='DelayTime', Combine=True)

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -351,7 +351,7 @@ for irun in sample:
     # instrument geometry to work out ToF ranges
     sampos = ws.getInstrument().getSample().getPos()
     l1 = (sampos - ws.getInstrument().getSource().getPos()).norm()
-    l2 = (ws.getDetector(0).getPos() - sampos).norm()
+    l2 = (ws.getDetector(ws.getSpectrumNumbers()[0]).getPos() - sampos).norm()
 
     # Updates ei_loop if auto _and_ not using monovan
     if use_auto_ei:

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -140,7 +140,11 @@ def tryload(irun):              # loops till data file appears
         try:
             ws = Load(str(irun),LoadMonitors=True)
         except TypeError:
-            ws = Load(str(irun),LoadMonitors='Separate')
+            try:
+                ws = Load(str(irun),LoadMonitors='Separate')
+            except ValueError: # Possibly when file is being copied over from NDX machine
+                Pause(2)
+                ws = Load(str(irun),LoadMonitors=True)
         except ValueError:
             print(f'...waiting for run #{irun}')
             Pause(file_wait)

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -72,7 +72,7 @@ QENS = False                    # output Q-binned data for QENS data analysis '_
 Qbins = 20                      # approximate number of Q-bins for QENS
 theta_range = [5., 65.]         # useful theta range for Q-binning (QENS)
 idebug = False                  # keep workspaces and check absolute units on elastic line
-save_dir = f'/instrument/{inst}/RBNumber/USER_RB_FOLDER'  # Set to None to avoid reseting
+save_dir = f'/data/analysis/{inst}/RBNumber/USER_RB_FOLDER'  # Set to None to avoid reseting
 psi_motor_name = 'rot'          # name of the rotation motor in the logs
 angles_workspace = 'angles_ws'  # name of workspace to store previously seen angles
 sumruns_savemem = False         # Compresses event in summed ws to save memory
@@ -111,10 +111,12 @@ else:
 
 cycle_shortform = cycle[2:] if cycle.startswith('20') else cycle
 datadir = f'/archive/NDX{inst}/Instrument/data/cycle_{cycle_shortform}/'
+datadir2 = f'/data/instrument/{inst}/CYCLE_20{cycle_shortform.replace("_","")}/USER_RB_FOLDER/'
 instfiles  = '/usr/local/mprogs/InstrumentFiles/'
 mapdir  = f'{instfiles}/{inst.swapcase()}/'
 config.appendDataSearchDir(mapdir)
 config.appendDataSearchDir(datadir)
+config.appendDataSearchDir(datadir2)
 ws_list = ADS.getObjectNames()
 
 # Try to load subsidiary utilities

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -268,13 +268,17 @@ if is_auto(Ei_list) or hasattr(Ei_list, '__iter__') and is_auto(Ei_list[0]):
     use_auto_ei = True
     try:
         Ei_list = autoei(ws)
-    except NameError:
+    except (NameError, RuntimeError) as e:
         fn = str(sample[0])
         if not fn.startswith(inst[:3]): fn = f'{inst[:3]}{fn}'
         if fn.endswith('.raw'): fn = fn[:-4]
         if fn[-4:-2] == '.s': fn = fn[:-4] + '.n0' + fn[-2:]
         if not fn.endswith('.nxs') and fn[-5:-2] != '.n0': fn += '.nxs'
-        Ei_list = autoei(LoadNexusMonitors(fn, OutputWorkspace='ws_tmp_mons'))
+        ws_tmp_mons = LoadNexusMonitors(fn, OutputWorkspace='ws_tmp_mons')
+        Ei_list = autoei(ws_tmp_mons)
+    if not Ei_list:
+        raise RuntimeError(f'Invalid run(s) {sample}. Chopper(s) not running ' \
+                            'or could not determine neutron energy')
     print(f"Automatically determined Ei's: {Ei_list}")
     if len(trans) < len(Ei_list):
         print(f'{inst}: WARNING - not enough transmision values for auto-Ei. ' \

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -111,7 +111,7 @@ else:
 
 cycle_shortform = cycle[2:] if cycle.startswith('20') else cycle
 datadir = f'/archive/NDX{inst}/Instrument/data/cycle_{cycle_shortform}/'
-datadir2 = f'/data/instrument/{inst}/CYCLE_20{cycle_shortform.replace("_","")}/USER_RB_FOLDER/'
+datadir2 = f'/data/instrument/{inst}/CYCLE20{cycle_shortform.replace("_","")}/USER_RB_FOLDER/'
 instfiles  = '/usr/local/mprogs/InstrumentFiles/'
 mapdir  = f'{instfiles}/{inst.swapcase()}/'
 config.appendDataSearchDir(mapdir)
@@ -224,11 +224,12 @@ else:
 # =======================load background runs and sum=========================
 if sample_cd is not None:
     ws_cd = load_sum(sample_cd)
+    ws_cd = NormaliseByCurrent(ws_cd)
 if sample_bg is not None:
     ws_bg = load_sum(sample_bg)
+    ws_bg = NormaliseByCurrent(ws_bg)
     if sample_cd is not None:
         ws_bg = ws_bg - ws_cd
-    ws_bg = NormaliseByCurrent(ws_bg)
 
 # ==========================continuous scan stuff=============================
 if cs_block and cs_bin_size > 0:

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -49,8 +49,6 @@ same_angle_action = 'ignore'
 cs_block = None
 cs_block_unit = ''
 cs_bin_size = 0
-# MARI only: used to subtract an analytic approx of instrument background
-sub_ana = False
 #========================================================
 
 #==================Absolute Units Inputs=================
@@ -150,18 +148,6 @@ def tryload(irun):              # loops till data file appears
         break
     if inst == 'MARI':
         remove_extra_spectra_if_mari('ws')
-        if sub_ana is True and not sample_cd:
-            if 'bkg_ev' not in mtd:
-                gen_ana_bkg()
-            current = mtd['ws'].run().getProtonCharge()
-            if isinstance(mtd['ws'], mantid.dataobjects.EventWorkspace):
-                ws = mtd['ws'] - mtd['bkg_ev'] * current
-            else:
-                try:
-                    ws = mtd['ws'] - mtd['bkg_his'] * current
-                except ValueError:
-                    gen_ana_bkg(target_ws=mtd['ws'])
-                    ws = mtd['ws'] - mtd['bkg_his'] * current
     return mtd['ws']
 
 def load_sum(run_list, block_name=None):
@@ -459,8 +445,6 @@ for irun in sample:
                 ofile_suffix += 'sum'
             if sample_bg is not None:
                 ofile_suffix += '_sub'
-            if sub_ana:
-                ofile_suffix += '_sa'
 
         # output nxspe file
         ofile = f'{ofile_prefix}_{origEi:g}meV{ofile_suffix}'

--- a/reduction_files/DG_whitevan.py
+++ b/reduction_files/DG_whitevan.py
@@ -43,7 +43,7 @@ if save_dir is not None:
 cycle_shortform = cycle[2:] if cycle.startswith('20') else cycle
 data_dir = f'/archive/NDX{inst}/Instrument/data/cycle_{cycle_shortform}/'
 config.appendDataSearchDir(data_dir)
-data_dir = f'/data/instrument/{inst}/CYCLE_20{cycle_shortform.replace("_","")}/USER_RB_FOLDER/'
+data_dir = f'/data/instrument/{inst}/CYCLE20{cycle_shortform.replace("_","")}/RB0/'
 config.appendDataSearchDir(data_dir)
 if save_dir is not None:
     config.appendDataSearchDir(save_dir)

--- a/reduction_files/DG_whitevan.py
+++ b/reduction_files/DG_whitevan.py
@@ -33,7 +33,7 @@ cycle = 'CYCLE_ID'                      # cycle
 wv_lrange = [1,5]                       # wavelength integration limits for output of vanadium integrals
 wv_detrange = [30000,60000]             # spectrum index range for average intensity calculation
 idebug = False                          # keep itermediate workspaces for debugging
-save_dir = f'/instrument/{inst}/RBNumber/USER_RB_FOLDER' # Set to None to avoid resetting
+save_dir = f'/data/analysis/{inst}/RBNumber/USER_RB_FOLDER' # Set to None to avoid resetting
 #========================================================
 #!end_params
 
@@ -42,6 +42,8 @@ if save_dir is not None:
     config['defaultsave.directory'] = save_dir
 cycle_shortform = cycle[2:] if cycle.startswith('20') else cycle
 data_dir = f'/archive/NDX{inst}/Instrument/data/cycle_{cycle_shortform}/'
+config.appendDataSearchDir(data_dir)
+data_dir = f'/data/instrument/{inst}/CYCLE_20{cycle_shortform.replace("_","")}/USER_RB_FOLDER/'
 config.appendDataSearchDir(data_dir)
 if save_dir is not None:
     config.appendDataSearchDir(save_dir)

--- a/reduction_files/DG_whitevan.py
+++ b/reduction_files/DG_whitevan.py
@@ -59,6 +59,9 @@ def try_load_no_mon(irun, ws_name=None):
         ws_name = ws_name[0]
     try:
         return Load(str(irun), LoadMonitors='Exclude', OutputWorkspace=ws_name)
+    except RuntimeError:
+        ws_load = Load(str(irun), LoadMonitors='Include', OutputWorkspace=ws_name)
+        ExtractMonitors(ws_load, DetectorWorkspace=ws_name, MonitorWorkspace=ws_name+'_monitors')
     except ValueError:
         return Load(str(irun), LoadMonitors=False, OutputWorkspace=ws_name)
 

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -535,12 +535,15 @@ def iliad(runno, ei, wbvan, monovan=None, sam_mass=None, sam_rmm=None, sum_runs=
         kwargs['sumruns'] = True
     if monovan is not None and isinstance(monovan, (int, float)) and monovan > 0:
         mv_file = f'MV_{monovan}.txt'
-        mvkw = {'mask':kwargs['mask']} if 'mask' in kwargs else {}
-        if 'inst' in kwargs: mvkw['inst'] = kwargs['inst']
+        mvkw = {}
+        for pp in [v for v in ['mask', 'inst'] if v in kwargs]:
+            mvkw[pp] = kwargs[pp]
         try:
-            LoadAscii(wv_file, OutputWorkspace=wv_file)
+            LoadAscii(mv_file, OutputWorkspace=mv_file)
+            ReplaceSpecialValues(mv_file, SmallNumberThreshold=1e-20, SmallNumberValue='NaN', OutputWorkspace=mv_file)
         except ValueError:
             run_monovan(monovan=monovan, Ei_list=Ei_list, wv_file=wv_file, **mvkw)
         kwargs['sample_mass'] = sam_mass
         kwargs['sample_fwt'] = sam_rmm
+        kwargs['mv_file'] = mv_file
     run_reduction(sample=runno, Ei_list=ei if hasattr(ei, '__iter__') else [ei], wv_file=wv_file, **kwargs)

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -228,6 +228,20 @@ def gen_ana_bkg(quietws='MAR29313', target_ws=None):
     bkg_ev = ConvertToEventWorkspace(wx)
     return bkg_ev, wx
 
+def mari_remove_ana_bkg(wsname):
+    if sub_ana is True and not sample_cd:
+        if 'bkg_ev' not in mtd:
+            gen_ana_bkg()
+        current = mtd[wsname].run().getProtonCharge()
+        if isinstance(mtd[wsname], mantid.dataobjects.EventWorkspace):
+            ws = mtd[wsname] - mtd['bkg_ev'] * current
+        else:
+            try:
+                ws = mtd[wsname] - mtd['bkg_his'] * current
+            except ValueError:
+                gen_ana_bkg(target_ws=mtd[wsname])
+                ws = mtd[wsname] - mtd['bkg_his'] * current
+
 #========================================================
 # Auto-Ei routine
 

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -478,6 +478,10 @@ def iliad(runno, ei, wbvan, monovan=None, sam_mass=None, sam_rmm=None, sum_runs=
         ReplaceSpecialValues(wv_file, SmallNumberThreshold=1e-20, SmallNumberValue='NaN', OutputWorkspace=wv_file)
     except ValueError:
         run_whitevan(whitevan=wbvan, **wv_args)
+        ws = mtd['WV_normalised_integrals']
+        if ws.getNumberHistograms() == 919:
+            RemoveSpectra(ws, [0], OutputWorkspace=ws.name())
+            SaveAscii(ws, wv_file)
     Ei_list = ei if hasattr(ei, '__iter__') else [ei]
     if 'hard_mask_file' in kwargs:
         kwargs['mask'] = kwargs.pop('hard_mask_file')


### PR DESCRIPTION
Updated instrument info parsing:

+ Change data type of chopper speed to float32
+ Fix energy data type (was int32, should have been float32)
+ Parses "rep_xxx" fields in raw nxs correctly, and omits them from nxspe files
+ Removes references to spectra in `detector_elements_1` - has only one mapping from detector to workspaces now (workspaces are Horace terms, Mantid calls these spectra).

Other bugfixes:

+ Update new IDAaaS paths (RB/experiment specific)
+ Add a NormaliseByCurrent step to Cd runs
+ Make error message if auto-Ei fails more understandable
+ Remove MARI high instrument background subtraction routines (copy kept in reduction_utils for future info)
+ Add extra try/catch ValueError to handle files which are incompletely written (when using the "wait for file to exist" mode)
+ Fix bug where L2 is obtained from detector which doesn't exist (detector 0 does not always exist).
+ Fix DG_monovan for `fixedei=True` (port code from DG_reduction)
+ Workaround dodgy LET `.raw` file loading in DG_whitevan where the file has no monitors
