### PR TITLE
Bugfixes for cycle 25/3

### DIFF
--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -94,7 +94,7 @@ if inst == 'MARI':
     same_angle_action = 'ignore'
 elif inst == 'MERLIN':
     source = 'undulator'
-    m2spec = 69636              # specID of monitor2 (pre-sample)
+    m2spec = 69634              # specID of monitor2 (pre-sample)
     m3spec = 69640              # specID of monitor3 (post-sample)
     #monovan_mass = 32.62       # mass of vanadium cylinder
 elif inst == 'MAPS':

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -252,8 +252,8 @@ if cs_block and cs_bin_size > 0:
     print(f'... N={bval_nbins} bins with {bval_remainder:.2f} {unit} remainder')
 if cs_conv_to_md:
     powder = False
-    assert(all([v in cs_conv_pars for v in ['lattice_pars', 'lattice_ang', 'u', 'v', 'psi0']]),
-        'Conversion to MDWorkspace needs parameters: "lattice_pars", "lattice_ang", "u", "v", "psi0"')
+    assert all([v in cs_conv_pars for v in ['lattice_pars', 'lattice_ang', 'u', 'v', 'psi0']]), \
+        'Conversion to MDWorkspace needs parameters: "lattice_pars", "lattice_ang", "u", "v", "psi0"'
 
 # =======================sum sample runs if required=========================
 sumsuf = sumruns and len(sample) > 1
@@ -412,8 +412,7 @@ for irun in sample:
         print('... t2e section')
         ws_monitors = mtd['ws_monitors']
         spectra = ws_monitors.getSpectrumNumbers()
-        index = spectra.index(m2spec)
-        m2pos = ws.detectorInfo().position(index)[2]
+        m2pos = ws.detectorInfo().position(spectra.index(m2spec))[2]
 
         if inst == 'MARI' and utils_loaded and origEi < 4.01:
             # Shifts data / monitors into second frame for MARI

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -268,14 +268,13 @@ if is_auto(Ei_list) or hasattr(Ei_list, '__iter__') and is_auto(Ei_list[0]):
     try:
         Ei_list = autoei(ws)
     except (NameError, RuntimeError) as e:
-        fn = str(sample[0])
-        if not fn.startswith(inst[:3]): fn = f'{inst[:3]}{fn}'
-        if fn.endswith('.raw'): fn = fn[:-4]
-        if fn[-4:-2] == '.s': fn = fn[:-4] + '.n0' + fn[-2:]
-        if not fn.endswith('.nxs') and fn[-5:-2] != '.n0': fn += '.nxs'
-        ws_tmp_mons = LoadNexusMonitors(fn, OutputWorkspace='ws_tmp_mons')
-        Ei_list = autoei(ws_tmp_mons)
-    if not Ei_list:
+        fn = str(sample[0]).split(inst[:3])[-1].replace('.raw', '.nxs').replace('.s','.n0')
+        try:
+            ws_tmp_mons = LoadNexusMonitors(fn, OutputWorkspace='ws_tmp_mons')
+            Ei_list = autoei(ws_tmp_mons)
+        except:
+            pass
+    if not Ei_list and mv_file is not None:
         raise RuntimeError(f'Invalid run(s) {sample}. Chopper(s) not running ' \
                             'or could not determine neutron energy')
     print(f"Automatically determined Ei's: {Ei_list}")
@@ -309,7 +308,7 @@ if mv_file is not None and monovan_mass is not None:
         mv_fac.append(mvf)
 else:
     print(f'{inst}: Skipping absolute calibration')
-    mv_fac = [x/x for x in Ei_list]     # monovan factors = 1 by default
+    mv_fac = [1.0 for x in Ei_list]     # monovan factors = 1 by default
 
 # =====================angles cache stuff====================================
 if utils_loaded:

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -352,10 +352,10 @@ for irun in sample:
             tryload(irun)
             print(f'Loading run# {irun}')
 
-    try:
-        ws = NormaliseByCurrent('ws')
-    except RuntimeError:
-        pass
+    # Fixes the current if it's been corrupted by a bug in Mantid
+    if mtd['ws'].getRun().getLogData('gd_prtn_chrg').value == 0:
+        AddSampleLog('ws', 'gd_prtn_chrg', str(np.sum(mtd['ws'].getRun().getLogData('proton_charge').value)), 'Number')
+    ws = NormaliseByCurrent('ws')
     if sumruns and sumruns_savemem:
         ws = CompressEvents(ws, Tolerance=1e-5)  # Tolerance in microseconds
 

--- a/reduction_files/DG_reduction.py
+++ b/reduction_files/DG_reduction.py
@@ -199,6 +199,7 @@ if sample_cd is not None and (isinstance(sample_cd, str) or not hasattr(sample_c
 if mask is None:
     print(f'{inst}: WARNING - No hard mask!  Bad detectors wont be removed')
 if mask not in ws_list and mask is not None:
+    assert mask.endswith('xml') or mask.endswith('msk'), 'Mask file should be .msk or .xml'
     print(f'{inst}: Loading hard mask - {mask}')
     LoadMask(inst,mask,OutputWorkspace=mask)
 else:

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -398,7 +398,7 @@ def autoei(ws):
             ei_nominal = ((2286.26 * lmc) / delay)**2
         sqrt_ei = np.sqrt(ei_nominal)
         delay_calc = ((2286.26 * lmc) / sqrt_ei)
-        t_offset_ref = {'S':2033.3/freq-5.4, 'G':1339.9/freq-7.3}
+        t_offset_ref = {'S':2033.3/freq-5.4, 'G':1339.9/freq-7.3, 'A':-4790.69/freq+17.7}
         t_offset = delay - (delay_calc % period)
         chopper_type = min(t_offset_ref.keys(), key=lambda x:np.abs(t_offset - t_offset_ref[x]))
         nom_disk1, nom_disk2 = (((2286.26 * l) / sqrt_ei) - c for l, c in zip([7.861, 7.904], [5879., 6041.]))
@@ -409,6 +409,8 @@ def autoei(ws):
         slots = {0:[0,1,2,4], 1:[0,1], 2:[0,2], 3:[0], 4:[0]}[abs(int(slots_delta))]
         disk_ref = 6 - (np.round(delt_disk1 / 202.11) / 10)
         assert disk_ref % 1.0 < 0.2, f'Bad disk calculation'
+        if chopper_type.upper() == 'A' and disk_ref == 0:
+            disk_ref = 1
         disk = {0:disk_ref, 1:disk_ref-1, 2:1 if disk_ref==2 else 0, 3:0, 4:0}[abs(int(slots_delta))]
         reps = [d-disk for d in slots]
         eis_disk = {((2286.26*lmc) / (delay_calc + s*2500.))**2 for s in reps}

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -413,7 +413,10 @@ def autoei(ws):
         reps = [d-disk for d in slots]
         eis_disk = {((2286.26*lmc) / (delay_calc + s*2500.))**2 for s in reps}
         period = period / 2. if 'G' in chopper_type.upper() else period
-        eis = {((2286.26*lmc) / (delay_calc + s*period))**2 for s in range(-10, 10)}
+        eis = {((2286.26*lmc) / (delay_calc + s*period))**2 for s in range(-10, 10) if (delay_calc+s*period) > 0}
+        # If disk is off, assume open and let all reps through
+        if abs(mode(getLog('Freq_Thick_1'))) < 1:
+            eis_disk = [ei for ei in eis if ei > (2.9 if 'G' in chopper_type.upper() else 40)]
         inrange = lambda x: (x > 1 and x < 2.9) or (x > 4 and x < 1000)
         return [roundlog10(ei) for ei in np.sort(list(eis.intersection(eis_disk)))[::-1] if inrange(ei)]
 

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -48,7 +48,7 @@ def _get_mon_from_history(ws_name):
         raise RuntimeError(f'Cannot find original file from workspace {ws_name} to load logs from')
     try:
         LoadEventNexus(orig_file, SpectrumMax=10, LoadMonitors=True, OutputWorkspace='tmp_mons')
-    except TypeError:
+    except (TypeError, ValueError) as err:
         LoadRaw(orig_file, SpectrumMax=10, LoadMonitors='Separate', OutputWorkspace='tmp_mons')
     ws_mon_name = f'{ws_name}_monitors'
     RenameWorkspace('tmp_mons_monitors', ws_mon_name)

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -406,12 +406,10 @@ def autoei(ws):
         disk_delta = delt_disk2 - delt_disk1
         slots_delta = np.round(disk_delta / 202.11) / 10
         assert slots_delta % 1.0 < 0.2, 'Bad slots calculation'
-        slots = {0:[0,1,2,4], 1:[0,1], 2:[0,2], 3:[0], 4:[0]}[abs(int(slots_delta))]
+        slots = {0:[0,1,2,4], 1:[0,1], 2:[0,2], 3:[0], 4:[0]}[abs(int(round(slots_delta)))]
         disk_ref = 6 - (np.round(delt_disk1 / 202.11) / 10)
         assert disk_ref % 1.0 < 0.2, f'Bad disk calculation'
-        if chopper_type.upper() == 'A' and disk_ref == 0:
-            disk_ref = 1
-        disk = {0:disk_ref, 1:disk_ref-1, 2:1 if disk_ref==2 else 0, 3:0, 4:0}[abs(int(slots_delta))]
+        disk = {0:disk_ref, 1:disk_ref-1, 2:1 if disk_ref==2 else 0, 3:0, 4:0}[abs(int(round(slots_delta)))]
         reps = [d-disk for d in slots]
         eis_disk = {((2286.26*lmc) / (delay_calc + s*2500.))**2 for s in reps}
         period = period / 2. if 'G' in chopper_type.upper() else period

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -477,7 +477,8 @@ def controt_fill_in_log(ws_full, cs_block):
     print('## Reconstructing log by interpolation, this can take up to a minute.')
     onesec = np.timedelta64(1, 's')
     logval = ws_full.getRun().getLogData(cs_block)
-    logs = [[logval.filtered_times[ii], logval.filtered_value[ii]] for ii in range(logval.size())]
+    start = ws_full.getRun().startTime().to_datetime64()
+    logs = [[logval.times[ii], logval.value[ii]] for ii in range(len(logval.value)) if logval.times[ii] > start]
     AddTimeSeriesLog(ws_full, cs_block, str(logs[0][0]), logs[0][1], DeleteExisting=True)
     for ii in range(len(logs)-1):
         tdif, vdif = (logs[ii+1][0] - logs[ii][0], logs[ii+1][1] - logs[ii][1])

--- a/reduction_files/reduction_utils.py
+++ b/reduction_files/reduction_utils.py
@@ -471,6 +471,28 @@ def autoei(ws):
 
 
 #========================================================
+# Continuous rotation routines
+def controt_fill_in_log(ws_full, cs_block):
+    print('## Continuous rotation log interval larger than 1s!')
+    print('## Reconstructing log by interpolation, this can take up to a minute.')
+    onesec = np.timedelta64(1, 's')
+    logval = ws_full.getRun().getLogData(cs_block)
+    logs = [[logval.filtered_times[ii], logval.filtered_value[ii]] for ii in range(logval.size())]
+    AddTimeSeriesLog(ws_full, cs_block, str(logs[0][0]), logs[0][1], DeleteExisting=True)
+    for ii in range(len(logs)-1):
+        tdif, vdif = (logs[ii+1][0] - logs[ii][0], logs[ii+1][1] - logs[ii][1])
+        if tdif > onesec and abs(vdif) > 0:
+            newstep = int(tdif / onesec)
+            v0 = logs[ii][1]
+            vdif = vdif / newstep
+            for jj in range(1, newstep):
+                tim = logs[ii][0] + onesec*jj
+                AddTimeSeriesLog(ws_full, cs_block, str(tim), v0 + vdif*jj)
+        else:
+            AddTimeSeriesLog(ws_full, cs_block, str(logs[ii][0]), logs[ii][1])
+
+
+#========================================================
 # Iliad driver routines
 
 _DGRED = None

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -205,8 +205,7 @@ class DGReductionTest(unittest.TestCase):
                     'sample\s*=\s*\\[*[\\]0-9,]+':'sample = 59151',
                     'sample_bg\s*=\s*\\[*[\\]0-9,]+':'sample_bg = None',
                     'wv_file\s*=\s*[\\\'A-z0-9\\.]*':'wv_file = \'WV_57088.txt\'',
-                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]+.*':'Ei_list = [150]',
-                    'fixei = True':'fixei = False'}
+                    'Ei_list\s*=\s*[\\[\\]\\.0-9,]+.*':'Ei_list = [150]'}
         s_api.config['default.instrument'] = 'MERLIN'
         infile = os.path.join(self.scriptpath, 'DG_whitevan.py')
         outfile = os.path.join(self.outputpath, 'merlin_whitevan.py')
@@ -220,7 +219,7 @@ class DGReductionTest(unittest.TestCase):
         filepath = os.path.join(self.outputpath, 'MER59151_150meV_powder.nxspe')
         self.assertTrue(os.path.exists(filepath))
         cksum = {'MER59151_150meV_powder.nxspe':self.load_return_sum(filepath)}
-        assert_allclose(cksum['MER59151_150meV_powder.nxspe'], [1.3581422074777563e-06, 0.0])
+        assert_allclose(cksum['MER59151_150meV_powder.nxspe'], [1.2184365985892125e-06, 0.0])
 
 
     def test_MAPS(self):


### PR DESCRIPTION
Bugfixes from cycle 25/3:

* Add 'A' chopper and disk-parked-open option to `autoei` for MARI (and a small bugfix in phase calculations).
* Makes determining energies in `autoei` before main loop optional if monovan not used (it's only needed for a monovan input file energy consistency check).
* Add an interpolation function for continuous rotations where `Rot` logging wasn't updated to 1s interval.
* Change continuous rotation binning to use unfiltered times to handle summed runs.
* Add check that mask file is `.msk` or `.xml`.
* Update MERLIN monitor 2 index number which changed in this cycle (which required changing the test to use `fixei=True` as it uses old data where there is no peak).

There were also some changes to handle live-data autoreduction on MERLIN:

* Add option to specify full path to input files in `iliad` and to preload these files in order to make it run faster than the Mantid path searches (and in cases where the files are not on the Mantid path).
* Make current-normalisation step optional as live-data doesn't have integrated current logged.
* Don't crop workspaces to ToF range close to Ei to save memory because live-data doesn't have monitor histogram data to determine full ToF range.
* Fix `inst-data` copy error as live-data files don't have the same NeXus structure as real raw files.